### PR TITLE
Docker containerization for portable APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ This application can be used as a seed to quick start your spring boot REST API 
 
 
 ## To run the application
-Use one of the several ways of running a Spring Boot application. Below are just two options:
+Use one of the several ways of running a Spring Boot application. Below are just three options:
 
 1. Build using maven goal: `mvn clean package` and execute the resulting artifact as follows `java -jar springboot-jwt-0.0.1-SNAPSHOT.jar` or
 2. On Unix/Linux based systems: run `mvn clean package` then run the resulting jar as any other executable `./springboot-jwt-0.0.1-SNAPSHOT.jar`
+3. Build and start as a Docker container. Instructions at: [README](src/main/docker/README.md)
+
 
 ## To test the application
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,12 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
+		
+	    <base>frolvlad/alpine-oraclejdk8:slim</base>
+	    <tomcat.port>9081</tomcat.port>
+	    <tomcat.ip>127.0.0.1</tomcat.ip>
+	    <file>readme</file>
+	    
 	</properties>
 
 	<dependencies>
@@ -80,16 +86,54 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <executable>true</executable>
+					<addResources>true</addResources>
                 </configuration>
-            </plugin>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+			</plugin>
+			
+	         <plugin>
+		        <groupId>io.fabric8</groupId>
+		        <artifactId>docker-maven-plugin</artifactId>
+		        <extensions>true</extensions>
+		        
+ 		        <configuration>
+		          <images>
+			            <image>
+			              <name>springboot-jwt</name>
+			              <alias>springboot-jwt</alias>
+			              <build>
+			                <filter>@</filter>
+			                <dockerFileDir>${project.basedir}/src/main/docker</dockerFileDir>
+			                <assembly>
+			                  <descriptorRef>artifact</descriptorRef>
+			                </assembly>
+			              </build>
+			              <run>
+			              	<namingStrategy>alias</namingStrategy>
+			                <ports> 
+			                  <port>${tomcat.port}:8080</port>
+			                </ports>
+					         <wait> 
+					           <http>
+					              <url>http://${tomcat.ip}:${tomcat.port}/health</url>
+					           </http>
+					           <time>90000</time>
+					         </wait>
+			              </run>
+			            </image>
+		          </images>
+		        </configuration>	
+		        	
+		      </plugin>
 		</plugins>
 	</build>
-
 
 </project>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM frolvlad/alpine-oraclejdk8:slim
+ADD maven/springboot-jwt-0.0.1-SNAPSHOT.jar app.jar
+#RUN sh -c 'touch /app.jar'
+ENV JAVA_OPTS=""
+ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar" ]

--- a/src/main/docker/README.md
+++ b/src/main/docker/README.md
@@ -18,23 +18,27 @@ Now if you issue a `docker images` command you should see `springboot-jwt:latest
 ### Start container
 
 #### From Maven, default endpoint
-Basic usage: server IP 127.0.0.1, server port 9081
+Basic usage with defaults: server IP 127.0.0.1, server port 9081
+
 `mvn docker:start`
 
 #### From Maven, custom endpoint
 Advanced usage: custom server IP and server port
+
 `mvn docker:start "-Dtomcat.ip=<SERVER_IP>"  "-Dtomcat.port=<SERVER_PORT>"`
 
-where `<SERVER_IP>` is the IP address where Maven will test health check against (usually localhost, 127.0.0.1, or 192.168.99.100 on legacy Docker Toolbox running on a VirtualBox default image).
+where `<SERVER_IP>` and `<SERVER_PORT>` are the IP address and port where Maven will test health check against (usually localhost, 127.0.0.1, or 192.168.99.100 on legacy Docker Toolbox).
 
 #### From command line
-`docker run -d -p 9081:8080 springboot-jwt`
+`docker run -d -p <SERVER_PORT>:8080 springboot-jwt`
 
 Now if you issue a `docker ps` command you should see a new running container listed.
 
+To see logs:
+`docker logs -f <CONTAINERID>`
 
 ### Access to APIs
 Point your local browser to:
-`http://<SERVER_IP>:9091/health`
+`http://<SERVER_IP>:<SERVER_PORT>/health`
 
 You should see `{ status: "UP" }` message!

--- a/src/main/docker/README.md
+++ b/src/main/docker/README.md
@@ -1,0 +1,40 @@
+## SpringBoot JWT Container
+
+Following instructions explain how to publish springboot-jwt tutorial APIs via a portable Docker container.
+
+### Pre-requisites
+You need to have:
+- a Docker installation available locally. See [Docker website](https://docs.docker.com/install/) on installation instructions for Windows and Linux users.
+- at least 100MB of local storage.
+- springboot-jwt project sources locally compiled, and shell pointing to project root.
+
+
+### Build image
+`mvn clean package docker:build`
+
+Now if you issue a `docker images` command you should see `springboot-jwt:latest` image listed.
+
+
+### Start container
+
+#### From Maven, default endpoint
+Basic usage: server IP 127.0.0.1, server port 9081
+`mvn docker:start`
+
+#### From Maven, custom endpoint
+Advanced usage: custom server IP and server port
+`mvn docker:start "-Dtomcat.ip=<SERVER_IP>"  "-Dtomcat.port=<SERVER_PORT>"`
+
+where `<SERVER_IP>` is the IP address where Maven will test health check against (usually localhost, 127.0.0.1, or 192.168.99.100 on legacy Docker Toolbox running on a VirtualBox default image).
+
+#### From command line
+`docker run -d -p 9081:8080 springboot-jwt`
+
+Now if you issue a `docker ps` command you should see a new running container listed.
+
+
+### Access to APIs
+Point your local browser to:
+`http://<SERVER_IP>:9091/health`
+
+You should see `{ status: "UP" }` message!


### PR DESCRIPTION
After I tried this excellent tutorial, and protect my APIs with token based authentication, I soon needed to have a little portable OAuth2 server running near my application stack, for test and development purposes.
And the sample APIs of tutorial perfectly suited my needs.

So, I added basic containerization deployment capabilities through Docker and explained it through main README.md and README.md near Dockefile, as a third running mode (or deployment flavour).

Hope it helps someone else want to port this nice running tutorial!

PS: tested with Windows 8.1 (Docker Toolbox) and Linux (CentOS 7)